### PR TITLE
All storage keys not under control of h5webstorage are set to null when an h5webstorage bound key is updated.

### DIFF
--- a/src/basestorage.ts
+++ b/src/basestorage.ts
@@ -122,9 +122,9 @@ export abstract class BaseStorage implements OnDestroy, Storage {
 			var storage = this.getProperty<Storage>("storage");
 			var prevStorage = this.deserialize(prevValue);
 			Object.keys(this).forEach((key) => {
-				var _key = this.normalizeStorageKey(key, KeyDirection.To);
-				var value = this[key];
-				if (typeof this[key] != "undefined") {
+				if (this[key] != null) {
+					var _key = this.normalizeStorageKey(key, KeyDirection.To);
+					var value = this[key];
 					storage.setItem(_key, this.serialize(this[key]));
 					delete prevStorage[key];
 				}


### PR DESCRIPTION
**Steps to reproduce:**

1. Manually create a key using the standard localStorage API (eg. `localStorage.manualKey = 'test';`).
2. Bind to different key using h5webstorage (eg. `@StorageProperty() private h5Key;`) and set it to something.

**Expected outcome**

- `localStorage.firstKey` has the value `'test'`.

**Actual outcome**

- `localStorage.firstKey` has been set to `null`.

Sorry, no unit test, couldn't work out how to get them running.